### PR TITLE
add cli arg for config file

### DIFF
--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -24,9 +24,9 @@ class Config:
         """Dict style access for config values."""
         return self.data[key]
 
-    def set_path(self, path: Path):
+    def set_path(self, path: str):
         """Set the config file path."""
-        self.path = path
+        self.path = Path(path)
 
     def reload(self):
         """Reload config values from the disk."""

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -20,9 +20,6 @@ logger = logging.getLogger(__name__)
 class Config:
     """Representation of the config file."""
 
-    def __init__(self, path: Path = Path("/etc/cos-alerter.yaml")):
-        self.set_path(path)
-
     def __getitem__(self, key):
         """Dict style access for config values."""
         return self.data[key]

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -5,10 +5,10 @@
 
 import datetime
 import logging
-from pathlib import Path
 import textwrap
 import threading
 import time
+from pathlib import Path
 
 import apprise
 import durationpy
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 
 class Config:
     """Representation of the config file."""
+
     def __init__(self, path: Path = Path("/etc/cos-alerter.yaml")):
-        """Set the config file path."""
         self.set_path(path)
 
     def __getitem__(self, key):
@@ -28,6 +28,7 @@ class Config:
         return self.data[key]
 
     def set_path(self, path: Path):
+        """Set the config file path."""
         self.path = path
 
     def reload(self):

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -5,6 +5,7 @@
 
 import datetime
 import logging
+from pathlib import Path
 import textwrap
 import threading
 import time
@@ -18,14 +19,20 @@ logger = logging.getLogger(__name__)
 
 class Config:
     """Representation of the config file."""
+    def __init__(self, path: Path = Path("/etc/cos-alerter.yaml")):
+        """Set the config file path."""
+        self.set_path(path)
 
     def __getitem__(self, key):
         """Dict style access for config values."""
         return self.data[key]
 
+    def set_path(self, path: Path):
+        self.path = path
+
     def reload(self):
         """Reload config values from the disk."""
-        with open("/etc/cos-alerter.yaml", "r") as f:
+        with open(self.path, "r") as f:
             self.data = yaml.safe_load(f)
         self.data["watch"]["down_interval"] = durationpy.from_str(
             self.data["watch"]["down_interval"]

--- a/cos_alerter/daemon.py
+++ b/cos_alerter/daemon.py
@@ -47,6 +47,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--config",
         required=False,
+        default="/etc/cos-alerter.yaml",
         help="Path to config file. Defaults to /etc/cos-alerter.yaml",
     )
     return parser.parse_args(args=args)
@@ -74,8 +75,7 @@ def main(run_for: Optional[int] = None, argv: List[str] = sys.argv):
     """
     args = parse_args(argv[1:])
 
-    if args.config:
-        config.set_path(Path(args.config))
+    config.set_path(Path(args.config))
     config.reload()
     init_logging(args)
     AlerterState.initialize()

--- a/cos_alerter/daemon.py
+++ b/cos_alerter/daemon.py
@@ -10,7 +10,6 @@ import signal
 import sys
 import threading
 import time
-from pathlib import Path
 from typing import List, Optional
 
 import waitress
@@ -75,7 +74,7 @@ def main(run_for: Optional[int] = None, argv: List[str] = sys.argv):
     """
     args = parse_args(argv[1:])
 
-    config.set_path(Path(args.config))
+    config.set_path(args.config)
     config.reload()
     init_logging(args)
     AlerterState.initialize()

--- a/cos_alerter/daemon.py
+++ b/cos_alerter/daemon.py
@@ -6,11 +6,11 @@
 
 import argparse
 import logging
-from pathlib import Path
 import signal
 import sys
 import threading
 import time
+from pathlib import Path
 from typing import List, Optional
 
 import waitress
@@ -47,7 +47,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--config",
         required=False,
-        help='Path to config file. Defaults to /etc/cos-alerter.yaml'
+        help="Path to config file. Defaults to /etc/cos-alerter.yaml",
     )
     return parser.parse_args(args=args)
 

--- a/cos_alerter/daemon.py
+++ b/cos_alerter/daemon.py
@@ -6,6 +6,7 @@
 
 import argparse
 import logging
+from pathlib import Path
 import signal
 import sys
 import threading
@@ -43,6 +44,11 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         choices=list(LEVELS),
         help='Logging level. Overrides config value "log_level"',
     )
+    parser.add_argument(
+        "--config",
+        required=False,
+        help='Path to config file. Defaults to /etc/cos-alerter.yaml'
+    )
     return parser.parse_args(args=args)
 
 
@@ -68,6 +74,8 @@ def main(run_for: Optional[int] = None, argv: List[str] = sys.argv):
     """
     args = parse_args(argv[1:])
 
+    if args.config:
+        config.set_path(Path(args.config))
     config.reload()
     init_logging(args)
     AlerterState.initialize()

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -4,7 +4,6 @@
 import textwrap
 import threading
 import unittest.mock
-from pathlib import Path
 
 import apprise
 import freezegun
@@ -36,7 +35,7 @@ def fake_fs(fs):
     fs.create_file("/etc/cos-alerter.yaml")
     with open("/etc/cos-alerter.yaml", "w") as f:
         f.write(yaml.dump(CONFIG))
-    config.set_path(Path("/etc/cos-alerter.yaml"))
+    config.set_path("/etc/cos-alerter.yaml")
     config.reload()
     return fs
 

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -4,6 +4,7 @@
 import textwrap
 import threading
 import unittest.mock
+from pathlib import Path
 
 import apprise
 import freezegun
@@ -35,6 +36,7 @@ def fake_fs(fs):
     fs.create_file("/etc/cos-alerter.yaml")
     with open("/etc/cos-alerter.yaml", "w") as f:
         f.write(yaml.dump(CONFIG))
+    config.set_path(Path("/etc/cos-alerter.yaml"))
     config.reload()
     return fs
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -6,6 +6,7 @@ import subprocess
 import threading
 import time
 import unittest.mock
+from pathlib import Path
 
 import apprise
 import pytest
@@ -40,6 +41,7 @@ def fake_fs(fs):
                 }
             )
         )
+    config.set_path(Path("/etc/cos-alerter.yaml"))
     config.reload()
     return fs
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -6,7 +6,6 @@ import subprocess
 import threading
 import time
 import unittest.mock
-from pathlib import Path
 
 import apprise
 import pytest
@@ -41,7 +40,7 @@ def fake_fs(fs):
                 }
             )
         )
-    config.set_path(Path("/etc/cos-alerter.yaml"))
+    config.set_path("/etc/cos-alerter.yaml")
     config.reload()
     return fs
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import copy
-from pathlib import Path
 
 import pytest
 import yaml
@@ -36,7 +35,7 @@ def fake_fs(fs):
     fs.create_file("/etc/cos-alerter.yaml")
     with open("/etc/cos-alerter.yaml", "w") as f:
         f.write(yaml.dump(CONFIG))
-    config.set_path(Path("/etc/cos-alerter.yaml"))
+    config.set_path("/etc/cos-alerter.yaml")
     config.reload()
     return fs
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 import copy
+from pathlib import Path
 
 import pytest
 import yaml
@@ -35,6 +36,7 @@ def fake_fs(fs):
     fs.create_file("/etc/cos-alerter.yaml")
     with open("/etc/cos-alerter.yaml", "w") as f:
         f.write(yaml.dump(CONFIG))
+    config.set_path(Path("/etc/cos-alerter.yaml"))
     config.reload()
     return fs
 


### PR DESCRIPTION
## Issue
Closes #26.


## Solution
Add CLI arg to the daemon and use `/etc/cos-alerter.yaml` as default.


## Testing Instructions
Deploy **cos-alerter** by running `daemon.py --config <config_file>` and passing a different config path than the default.


## Release Notes
Add a CLI argument to customize the location of the config file.