### PR TITLE
add metrics endpoint to cos-alerter

### DIFF
--- a/cos_alerter/server.py
+++ b/cos_alerter/server.py
@@ -6,10 +6,12 @@
 import logging
 
 from flask import Flask, request
+from prometheus_flask_exporter import PrometheusMetrics
 
 from .alerter import AlerterState, config
 
 app = Flask(__name__)
+metrics = PrometheusMetrics(app)
 logger = logging.getLogger(__name__)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "apprise~=1.3",
   "durationpy",
   "flask~=2.2",
+  "prometheus_flask_exporter~=0.22",
   "waitress~=2.1",
   "pyyaml~=6.0"
 ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -63,6 +63,10 @@ def test_alive_updates_time(flask_client, fake_fs, state_init):
         assert state.data["alert_time"] > state.start_time
 
 
+def test_metrics_succeeds(flask_client, fake_fs, state_init):
+    assert flask_client.get("/metrics").status_code == 200
+
+
 def test_no_clientid(flask_client, fake_fs, state_init):
     assert flask_client.post("/alive").status_code == 400
 


### PR DESCRIPTION
## Issue
Closes #21.


## Solution
Use [`prometheus_flask_exporter`](https://pypi.org/project/prometheus-flask-exporter/) to add Flask-related metrics.

Default metrics:

<details>

```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 3256.0
python_gc_objects_collected_total{generation="1"} 4034.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 230.0
python_gc_collections_total{generation="1"} 20.0
python_gc_collections_total{generation="2"} 1.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="10",patchlevel="7",version="3.10.7"} 1.0
# HELP flask_exporter_info Information about the Prometheus Flask exporter
# TYPE flask_exporter_info gauge
flask_exporter_info{version="0.22.3"} 1.0
# HELP flask_http_request_duration_seconds Flask HTTP request duration in seconds
# TYPE flask_http_request_duration_seconds histogram
flask_http_request_duration_seconds_bucket{le="0.005",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="0.01",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="0.025",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="0.05",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="0.075",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="0.1",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="0.25",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="0.5",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="0.75",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="1.0",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="2.5",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="5.0",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="7.5",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="10.0",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_bucket{le="+Inf",method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_count{method="POST",path="/alive",status="200"} 2.0
flask_http_request_duration_seconds_sum{method="POST",path="/alive",status="200"} 0.0014437419995374512
flask_http_request_duration_seconds_bucket{le="0.005",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.01",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.025",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.05",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.075",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.1",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.25",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.5",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.75",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="1.0",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="2.5",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="5.0",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="7.5",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="10.0",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="+Inf",method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_count{method="GET",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_sum{method="GET",path="/alive",status="405"} 0.0004948409987264313
flask_http_request_duration_seconds_bucket{le="0.005",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.01",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.025",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.05",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.075",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.1",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.25",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.5",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.75",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="1.0",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="2.5",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="5.0",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="7.5",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="10.0",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="+Inf",method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_count{method="HEAD",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_sum{method="HEAD",path="/alive",status="405"} 0.00039787599962437525
flask_http_request_duration_seconds_bucket{le="0.005",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.01",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.025",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.05",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.075",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.1",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.25",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.5",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.75",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="1.0",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="2.5",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="5.0",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="7.5",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="10.0",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="+Inf",method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_count{method="PUT",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_sum{method="PUT",path="/alive",status="405"} 0.0003977230007876642
flask_http_request_duration_seconds_bucket{le="0.005",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.01",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.025",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.05",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.075",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.1",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.25",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.5",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.75",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="1.0",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="2.5",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="5.0",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="7.5",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="10.0",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="+Inf",method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_count{method="DELETE",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_sum{method="DELETE",path="/alive",status="405"} 0.0003792850002355408
flask_http_request_duration_seconds_bucket{le="0.005",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.01",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.025",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.05",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.075",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.1",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.25",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.5",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="0.75",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="1.0",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="2.5",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="5.0",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="7.5",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="10.0",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_bucket{le="+Inf",method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_count{method="PATCH",path="/alive",status="405"} 1.0
flask_http_request_duration_seconds_sum{method="PATCH",path="/alive",status="405"} 0.00040121699930750765
# HELP flask_http_request_duration_seconds_created Flask HTTP request duration in seconds
# TYPE flask_http_request_duration_seconds_created gauge
flask_http_request_duration_seconds_created{method="POST",path="/alive",status="200"} 1.6824332686297638e+09
flask_http_request_duration_seconds_created{method="GET",path="/alive",status="405"} 1.6824332686428015e+09
flask_http_request_duration_seconds_created{method="HEAD",path="/alive",status="405"} 1.682433268644001e+09
flask_http_request_duration_seconds_created{method="PUT",path="/alive",status="405"} 1.682433268645365e+09
flask_http_request_duration_seconds_created{method="DELETE",path="/alive",status="405"} 1.6824332686466384e+09
flask_http_request_duration_seconds_created{method="PATCH",path="/alive",status="405"} 1.6824332686478484e+09
# HELP flask_http_request_total Total number of HTTP requests
# TYPE flask_http_request_total counter
flask_http_request_total{method="POST",status="200"} 2.0
flask_http_request_total{method="GET",status="405"} 1.0
flask_http_request_total{method="HEAD",status="405"} 1.0
flask_http_request_total{method="PUT",status="405"} 1.0
flask_http_request_total{method="DELETE",status="405"} 1.0
flask_http_request_total{method="PATCH",status="405"} 1.0
# HELP flask_http_request_created Total number of HTTP requests
# TYPE flask_http_request_created gauge
flask_http_request_created{method="POST",status="200"} 1.6824332686298509e+09
flask_http_request_created{method="GET",status="405"} 1.6824332686428888e+09
flask_http_request_created{method="HEAD",status="405"} 1.682433268644078e+09
flask_http_request_created{method="PUT",status="405"} 1.6824332686454546e+09
flask_http_request_created{method="DELETE",status="405"} 1.6824332686467414e+09
flask_http_request_created{method="PATCH",status="405"} 1.6824332686479313e+09
# HELP flask_http_request_exceptions_total Total number of HTTP requests which resulted in an exception
# TYPE flask_http_request_exceptions_total counter
```

</details>

## Testing Instructions
You can check the `/metrics` page (there is also an added test for it).


## Release Notes
Add metrics endpoint to cos-alerter
