### PR TITLE
use ruff instead of flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,6 @@ cos-alerter = "cos_alerter.daemon:main"
 [tool.black]
 line-length = 99
 
-[tool.isort]
-profile = "black"
-
 [tool.ruff]
 line-length = 99
 extend-exclude = ["__pycache__", "*.egg_info"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 [tool.pyright]
 include = ["cos_alerter"]
 pythonVersion = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,21 +40,21 @@ line-length = 99
 [tool.isort]
 profile = "black"
 
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 [tool.pyright]
 include = ["cos_alerter"]

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ description = Apply coding style standards to code
 skip_install = True
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -22,17 +22,11 @@ description = Check code against coding style standards
 skip_install = True
 deps =
     black
-    flake8
-    flake8-docstrings
-    flake8-copyright
-    pyproject-flake8
-    isort
+    ruff
     codespell
 commands =
     codespell --skip .git --skip .tox --skip build --skip venv
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same!