### PR TITLE
add snapcraft recipe

### DIFF
--- a/.github/workflows/promote-snap.yaml
+++ b/.github/workflows/promote-snap.yaml
@@ -1,0 +1,45 @@
+name: Promote Snap
+
+on:
+  workflow_dispatch:
+    inputs:
+      promotion:
+        type: choice
+        description: Channel to promote from
+        options:
+          - edge -> beta
+          - beta -> candidate
+          - candidate -> stable
+
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+jobs:
+  promote:
+    name: Promote Snap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo snap install --classic --channel edge snapcraft
+      - name: Set target channel
+        env:
+          PROMOTE_FROM: ${{ github.event.inputs.promotion }}
+        run: |
+          if [ "${PROMOTE_FROM}" == "edge -> beta" ]; then
+            echo "promote-from=edge" >> ${GITHUB_ENV}
+            echo "promote-to=beta" >> ${GITHUB_ENV}
+          elif [ "${PROMOTE_FROM}" == "beta -> candidate" ]; then
+            echo "promote-from=beta" >> ${GITHUB_ENV}
+            echo "promote-to=candidate" >> ${GITHUB_ENV}
+          elif [ "${PROMOTE_FROM}" == "candidate -> stable" ]; then
+            echo "promote-from=candidate" >> ${GITHUB_ENV}
+            echo "promote-to=stable" >> ${GITHUB_ENV}
+          fi
+      - name: Fetch Revision
+        run: |
+          SNAP_RELEASES=$(curl -s -H "Snap-Device-Series: 16" "http://api.snapcraft.io/v2/snaps/info/cos-alerter?fields=revision")
+          REVISION=$(echo $SNAP_RELEASES | jq '."channel-map"[] | select(.channel.risk=="${{ env.promote-from }}").revision')
+          echo "revision=$REVISION" >> ${GITHUB_ENV}
+      - name: Promote Snap
+        run: |
+          snapcraft release cos-alerter ${{ env.revision }} ${{ env.promote-to }}

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -1,0 +1,35 @@
+name: Release Snap
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - snap/**
+
+
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/stable
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+
+      - name: Build Snap
+        run: snapcraft pack --output cos-alerter.snap
+
+      - name: Upload and Publish Snap
+        run: snapcraft upload --release edge cos-alerter.snap
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ cos-alerter.yaml
 dist
 venv
 *.egg-info
+*.snap
 **/__pycache__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0]
 
 - Added usage instructions to the readme (#51).
+- Added snapcraft build recipes and automation. (#52)
 
 ## [0.4.0] - 2023-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0]
+## [Unreleased]
 
 - Added usage instructions to the readme (#51).
 - Added snapcraft build recipes and automation. (#52)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ Homepage = "https://github.com/canonical/cos-alerter"
 [project.scripts]
 cos-alerter = "cos_alerter.daemon:main"
 
+[tool.setuptools.package-dir]
+cos_alerter = "cos_alerter"
+
 [tool.black]
 line-length = 99
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ Homepage = "https://github.com/canonical/cos-alerter"
 [project.scripts]
 cos-alerter = "cos_alerter.daemon:main"
 
-[tool.setuptools.package-dir]
-cos_alerter = "cos_alerter"
+[tool.setuptools]
+packages = ["cos_alerter"]
 
 [tool.black]
 line-length = 99

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# This file is needed for some reason to make snapcraft work.
+# https://github.com/snapcore/snapcraft/issues/4300
+
 from setuptools import setup
 
 setup()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,39 @@
+name: cos-alerter
+version: '0.0.1'
+summary: A watchdog alerting on alertmanager notification failures.
+license: Apache-2.0
+contact: simon.aronsson@canonical.com
+issues: https://github.com/canonical/cos-alerter/issues
+source-code: https://github.com/canonical/cos-alerter/
+website: https://charmhub.io/topics/canonical-observability-stack/
+description: |
+  COS Alerter is a watchdog used to alert on alertmanager notification failures.
+  By leveraging an always-firing alert rule routed specifically to cos-alerter, you'll
+  be alerted if the pings stop happening - meaning your alertmanager is likely malfunctioning.
+
+base: core22
+grade: stable
+confinement: strict
+compression: lzo
+
+plugs:
+  etc-cos-alerter:
+    interface: system-files
+    read:
+      - /etc/cos-alerter.yaml
+
+parts:
+  cos-alerter:
+    plugin: python
+    source: .
+
+apps:
+  daemon:
+    command: bin/cos-alerter --config /etc/cos-alerter.yaml
+    install-mode: disable
+    restart-condition: on-failure
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+      - etc-cos-alerter

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cos-alerter
-version: '0.5.0'
+version: '0.4.0'
 summary: A watchdog alerting on alertmanager notification failures.
 license: Apache-2.0
 contact: simon.aronsson@canonical.com

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cos-alerter
-version: '0.0.1'
+version: '0.5.0'
 summary: A watchdog alerting on alertmanager notification failures.
 license: Apache-2.0
 contact: simon.aronsson@canonical.com


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
COS Alerter is currently only available as a docker image, leaving snap users out.

## Solution
<!-- A summary of the solution addressing the above issue -->
Add a snapcraft build recipe

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
- `cos-alerter` has been registered on snapcraft.io
- snapcraft store credentials for publishing has been added as a secret
## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
Publish COS Alerter as a snap.