### PR TITLE
allow user to set listen address and port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-10-26
+
 - Added usage instructions to the readme (#51).
 - Added snapcraft build recipes and automation. (#52)
+- Added the ability to set the listen address and port for the web server. (#55)
 
 ## [0.4.0] - 2023-05-31
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @abuelodelanada @dstathis @lucabello @PietroPasotti @rbarry82 @sed-i @simskij
+*       @abuelodelanada @dstathis @lucabello @PietroPasotti @sed-i @simskij @mmkay @IbraAoad

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -55,7 +55,7 @@ def deep_update(base: dict, new: typing.Optional[dict]):
     if new is None:
         return
     for key in base:
-        if key in new and type(base[key]) == dict:
+        if key in new and isinstance(base[key], dict):
             deep_update(base[key], new[key])
         elif key in new:
             base[key] = new[key]

--- a/cos_alerter/config-defaults.yaml
+++ b/cos_alerter/config-defaults.yaml
@@ -35,3 +35,7 @@ notify:
 # The logging level of COS Alerter
 # Levels available: critical, error, warning, info, debug
 log_level: "info"
+
+# The address to listen on for http traffic.
+# Format HOST:PORT
+web_listen_addr: "0.0.0.0:8080"

--- a/cos_alerter/daemon.py
+++ b/cos_alerter/daemon.py
@@ -95,7 +95,12 @@ def main(run_for: Optional[int] = None, argv: List[str] = sys.argv):
     # from the daemon. It also facilitates communication over memory rather than files.
     # clear_untrusted_proxy_headers is set to suppress a DeprecationWarning.
     server_thread = threading.Thread(
-        target=waitress.serve, args=(app,), kwargs={"clear_untrusted_proxy_headers": True}
+        target=waitress.serve,
+        args=(app,),
+        kwargs={
+            "clear_untrusted_proxy_headers": True,
+            "listen": config["web_listen_addr"],
+        },
     )
     server_thread.daemon = True  # Makes this thread exit when the main thread exits.
     logger.info("Starting the web server thread.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cos-alerter"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
   { name="Dylan Stephano-Shachter", email="dylan.stephano-shachter@canonical.com" }
 ]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: cos-alerter
 summary: A liveness checker for self-monitoring.
 description: Receive regular pings from the cos stack and alert when they stop.
-version: "0.4.0"  # NOTE: Make sure this matches `cos-alerter` below
+version: "0.5.0"  # NOTE: Make sure this matches `cos-alerter` below
 base: ubuntu:22.04
 license: Apache-2.0
 platforms:
@@ -11,7 +11,7 @@ parts:
     plugin: python
     source: .
     python-packages:
-      - cos-alerter==0.4.0  # NOTE: Make sure this matches `version` above
+      - cos-alerter==0.5.0  # NOTE: Make sure this matches `version` above
     stage-packages:
       - python3-venv
 services:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cos-alerter
-version: '0.4.0'
+version: '0.5.0'
 summary: A watchdog alerting on alertmanager notification failures.
 license: Apache-2.0
 contact: simon.aronsson@canonical.com

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ commands =
 [testenv:static]
 description = Run static analysis checks
 deps =
+    types-pyyaml
+    types-waitress
     pyright
 commands =
     pyright


### PR DESCRIPTION
## Issue
Users need to be able to set the listen address and port of the https server. #54


## Solution
Create a  config option and forward it to waitress-serve.


## Testing Instructions
1. Change the listen address in the config file.
2. Run COS Alerter.
3. Check that it is listening on the correct port.


## Release Notes
Users can now set a custom listen address for the http server.