### PR TITLE
A more detailed list of clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.0] - 2023-11-29
+## [0.6.0] - 2023-11-30
 
 - Added badges to README.md (#62).
-- Config now accommodates client ID, key, and name, allowing users to specify individual client details.(#63).
+- Config now accommodates client ID, key, and name, allowing users to specify individual client details (#63).
+- Added client authentication using SHA512-hashed keys for enhanced security (#63).
 
 
 ## [0.5.0] - 2023-10-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2023-11-29
+
 - Added badges to README.md (#62).
+- Config now accommodates client ID, key, and name, allowing users to specify individual client details.(#63).
+
 
 ## [0.5.0] - 2023-10-26
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ receivers:
 - name: cos-alerter
   webhook_configs:
   - url: http://<cos-alerter-address>:8080/alive?clientid=<clientid>&key=<clientkey>
+  # The above URL should be configured with the appropriate values for clientid and key.
+  # - clientid: Unique identifier for the Alertmanager instance.
+  # - key: Secret key for authenticating and authorizing communication with COS Alerter.
 route:
   ...
   routes:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ receivers:
 ...
 - name: cos-alerter
   webhook_configs:
-  - url: http://<cos-alerter-address>:8080/alive?clientid=<clientid>
+  - url: http://<cos-alerter-address>:8080/alive?clientid=<clientid>&key=<clientkey>
 route:
   ...
   routes:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ receivers:
 - name: cos-alerter
   webhook_configs:
   - url: http://<cos-alerter-address>:8080/alive?clientid=<clientid>&key=<clientkey>
-  # The above URL should be configured with the appropriate values for clientid and key.
-  # - clientid: Unique identifier for the Alertmanager instance.
-  # - key: Secret key for authenticating and authorizing communication with COS Alerter.
 route:
   ...
   routes:

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -120,9 +120,10 @@ class AlerterState:
         #     ...
         # }
         state["clients"] = {}
-        for client in config["watch"]["clients"]:
+        for client_data in config["watch"]["clients"]:
+            client_id = client_data["id"]
             alert_time = None if config["watch"]["wait_for_first_connection"] else current_time
-            state["clients"][client] = {
+            state["clients"][client_id] = {
                 "lock": threading.Lock(),
                 "alert_time": alert_time,
                 "notify_time": None,

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -36,11 +36,7 @@ class Config:
         """Validate that keys in the clients dictionary are valid SHA-512 hashes."""
         for client_info in clients.values():
             client_key = client_info.get("key", "")
-            try:
-                is_valid = len(client_key) == 128
-            except (ValueError, TypeError):
-                is_valid = False
-
+            is_valid = len(client_key) == 128
             if client_key and not is_valid:
                 return False
         return True

--- a/cos_alerter/config-defaults.yaml
+++ b/cos_alerter/config-defaults.yaml
@@ -10,16 +10,15 @@ watch:
 
   # The list of Alertmanager instances we are monitoring. Alertmanager instances should be
   # configured with the clientid=<clientid> &key=<clientkey> parameters.
-  # <clientid> must be a valid UUID
   # eg:
   # clients:
-    # - id: clientuuid1
-    #   key: clientkey1
-    #   name: Instance Name 1
-    # - id: clientuuid2
-    #   key: clientkey2
-    #   name: Instance Name 2
-  clients: []
+    # clientid1:
+    #   key: "clientkey1"
+    #   name: "Instance Name 1"
+    # clientid2:
+    #   key: "clientkey2"
+    #   name: "Instance Name 2"
+  clients: {}
 
 notify:
 

--- a/cos_alerter/config-defaults.yaml
+++ b/cos_alerter/config-defaults.yaml
@@ -9,11 +9,16 @@ watch:
   wait_for_first_connection: true
 
   # The list of Alertmanager instances we are monitoring. Alertmanager instances should be
-  # configured with the clientid=<client> parameter.
+  # configured with the clientid=<clientid> &key=<clientkey> parameters.
+  # <clientid> must be a valid UUID
   # eg:
   # clients:
-  #   - "client0"
-  #   - "client1"
+    # - id: clientuuid1
+    #   key: clientkey1
+    #   name: Instance Name 1
+    # - id: clientuuid2
+    #   key: clientkey2
+    #   name: Instance Name 2
   clients: []
 
 notify:

--- a/cos_alerter/config-defaults.yaml
+++ b/cos_alerter/config-defaults.yaml
@@ -10,16 +10,16 @@ watch:
 
   # Configuration for monitoring Alertmanager instances.
   # - clientid: Unique identifier for the Alertmanager instance.
-  # - key: Secret key for authenticating and authorizing communication with COS Alerter. (Should be an SHA512 hash)
+  # - key: Secret key for authenticating and authorizing communication with COS Alerter. (Should be a SHA512 hash)
   # - name: Descriptive name for the instance.
   # eg:
   # clients:
-    # clientid1:
+    # clientid0:
     #   key: "822295b207a0b73dd4690b60a03c55599346d44aef3da4cf28c3296eadb98b2647ae18863cc3ae8ae5574191b60360858982fd8a8d176c0edf646ce6eee24ef9"
-    #   name: "Instance Name 1"
-    # clientid2:
+    #   name: "Instance Name 0"
+    # clientid1:
     #   key: "0415b0cad09712bd1ed094bc06ed421231d0603465e9841c959e9f9dcf735c9ce704df7a0c849a4e0db405c916f679a0e6c3f63f9e26191dda8069e1b44a3bc8"
-    #   name: "Instance Name 2"
+    #   name: "Instance Name 1"
   clients: {}
 
 notify:

--- a/cos_alerter/config-defaults.yaml
+++ b/cos_alerter/config-defaults.yaml
@@ -8,15 +8,17 @@ watch:
   # This allows you to configure COS Alerter before configuring Alertmanager.
   wait_for_first_connection: true
 
-  # The list of Alertmanager instances we are monitoring. Alertmanager instances should be
-  # configured with the clientid=<clientid> &key=<clientkey> parameters.
+  # Configuration for monitoring Alertmanager instances.
+  # - clientid: Unique identifier for the Alertmanager instance.
+  # - key: Secret key for authenticating and authorizing communication with COS Alerter. (Should be an SHA512 hash)
+  # - name: Descriptive name for the instance.
   # eg:
   # clients:
     # clientid1:
-    #   key: "clientkey1"
+    #   key: "822295b207a0b73dd4690b60a03c55599346d44aef3da4cf28c3296eadb98b2647ae18863cc3ae8ae5574191b60360858982fd8a8d176c0edf646ce6eee24ef9"
     #   name: "Instance Name 1"
     # clientid2:
-    #   key: "clientkey2"
+    #   key: "0415b0cad09712bd1ed094bc06ed421231d0603465e9841c959e9f9dcf735c9ce704df7a0c849a4e0db405c916f679a0e6c3f63f9e26191dda8069e1b44a3bc8"
     #   name: "Instance Name 2"
   clients: {}
 

--- a/cos_alerter/daemon.py
+++ b/cos_alerter/daemon.py
@@ -106,8 +106,7 @@ def main(run_for: Optional[int] = None, argv: List[str] = sys.argv):
     logger.info("Starting the web server thread.")
     server_thread.start()
 
-    for client_data in config["watch"]["clients"]:
-        clientid = client_data["id"]
+    for clientid, _ in config["watch"]["clients"].items():
         client_thread = threading.Thread(target=client_loop, args=(clientid,))
         client_thread.daemon = True  # Makes this thread exit when the main thread exits.
         logger.info("Starting worker thread for client: %s", clientid)

--- a/cos_alerter/daemon.py
+++ b/cos_alerter/daemon.py
@@ -106,7 +106,8 @@ def main(run_for: Optional[int] = None, argv: List[str] = sys.argv):
     logger.info("Starting the web server thread.")
     server_thread.start()
 
-    for clientid in config["watch"]["clients"]:
+    for client_data in config["watch"]["clients"]:
+        clientid = client_data["id"]
         client_thread = threading.Thread(target=client_loop, args=(clientid,))
         client_thread.daemon = True  # Makes this thread exit when the main thread exits.
         logger.info("Starting worker thread for client: %s", clientid)

--- a/cos_alerter/daemon.py
+++ b/cos_alerter/daemon.py
@@ -106,7 +106,7 @@ def main(run_for: Optional[int] = None, argv: List[str] = sys.argv):
     logger.info("Starting the web server thread.")
     server_thread.start()
 
-    for clientid, _ in config["watch"]["clients"].items():
+    for clientid in config["watch"]["clients"]:
         client_thread = threading.Thread(target=client_loop, args=(clientid,))
         client_thread.daemon = True  # Makes this thread exit when the main thread exits.
         logger.info("Starting worker thread for client: %s", clientid)

--- a/cos_alerter/server.py
+++ b/cos_alerter/server.py
@@ -64,7 +64,7 @@ def alive():
         return 'Clientid {params["clientid"]} not found. ', 404
 
     # Hash the key and compare with the stored hashed key
-    hashed_key = hashlib.sha256(key.encode()).hexdigest()
+    hashed_key = hashlib.sha512(key.encode()).hexdigest()
     if hashed_key != client_info.get("key", ""):
         logger.warning("Request %s provided an incorrect key.", request.url)
         return "Incorrect key for the specified clientid.", 401

--- a/cos_alerter/server.py
+++ b/cos_alerter/server.py
@@ -4,6 +4,7 @@
 """HTTP server for COS Alerter."""
 
 import logging
+import uuid
 
 import timeago
 from flask import Flask, render_template, request
@@ -14,6 +15,14 @@ from .alerter import AlerterState, config, now_datetime
 app = Flask(__name__)
 metrics = PrometheusMetrics(app)
 logger = logging.getLogger(__name__)
+
+
+def get_name_for_uuid(target_uuid, clients):
+    """Get the name corresponding to a given UUID from a list of clients."""
+    for client in clients:
+        if client["id"] == target_uuid:
+            return client["name"]
+    return None
 
 
 @app.route("/", methods=["GET"])
@@ -28,9 +37,10 @@ def dashboard():
             status = "up" if not state.is_down() else "down"
             if last_alert is None:
                 status = "unknown"
+            client_name = get_name_for_uuid(clientid, config["watch"]["clients"])
             clients.append(
                 {
-                    "clientid": clientid,
+                    "client_name": client_name,
                     "status": status,
                     "alert_time": alert_time,
                 }
@@ -44,16 +54,32 @@ def alive():
     # TODO Decide if we should validate the request.
     params = request.args
     clientid_list = params.getlist("clientid")  # params is a werkzeug.datastructures.MultiDict
-    if len(clientid_list) < 1:
-        logger.warning("Request %s has no clientid.", request.url)
-        return 'Parameter "clientid" required.', 400
-    if len(clientid_list) > 1:
-        logger.warning("Request %s specified clientid more than once.", request.url)
-        return 'Parameter "clientid" provided more than once.', 400
+    key_list = params.getlist("key")
+
+    if len(clientid_list) < 1 or len(key_list) < 1:
+        logger.warning("Request %s is missing clientid or key.", request.url)
+        return 'Parameters "clientid" and "key" are required.', 400
+    if len(clientid_list) > 1 or len(key_list) > 1:
+        logger.warning("Request %s specified clientid or key more than once.", request.url)
+        return 'Parameters "clientid" and "key" should be provided exactly once.', 400
     clientid = clientid_list[0]
-    if clientid not in config["watch"]["clients"]:
-        logger.warning("Request %s specified an unknown clientid.")
-        return 'Clientid {params["clientid"]} not found. ', 404
+    key = key_list[0]
+    try:
+        uuid.UUID(clientid, version=4)
+    except ValueError:
+        logger.warning("Request %s specified an invalid clientid.", request.url)
+        return f"Clientid {clientid} is not a valid UUID.", 400
+
+    clients = config["watch"]["clients"]
+    # Find the client with the specified clientid
+    matching_clients = [c for c in clients if c["id"] == clientid]
+    if not matching_clients:
+        logger.warning("Request %s specified an unknown clientid.", request.url)
+        return f"Clientid {clientid} not found.", 404
+    client = matching_clients[0]
+    if key != client["key"]:
+        logger.warning("Request %s provided an incorrect key.", request.url)
+        return "Incorrect key for the specified clientid.", 401
     logger.info("Received alert from Alertmanager clientid: %s.", clientid)
     with AlerterState(clientid) as state:
         state.reset_alert_timeout()

--- a/cos_alerter/server.py
+++ b/cos_alerter/server.py
@@ -68,14 +68,14 @@ def alive():
         uuid.UUID(clientid, version=4)
     except ValueError:
         logger.warning("Request %s specified an invalid clientid.", request.url)
-        return f"Clientid {clientid} is not a valid UUID.", 400
+        return 'Clientid {params["clientid"]} is not a valid UUID. ', 400
 
     clients = config["watch"]["clients"]
     # Find the client with the specified clientid
     matching_clients = [c for c in clients if c["id"] == clientid]
     if not matching_clients:
         logger.warning("Request %s specified an unknown clientid.", request.url)
-        return f"Clientid {clientid} not found.", 404
+        return 'Clientid {params["clientid"]} not found. ', 404
     client = matching_clients[0]
     if key != client["key"]:
         logger.warning("Request %s provided an incorrect key.", request.url)

--- a/cos_alerter/templates/dashboard.html
+++ b/cos_alerter/templates/dashboard.html
@@ -41,7 +41,7 @@
     <tbody>
       {% for client in clients %}
       <tr>
-        <td>{{ client["clientid"] }}</td>
+        <td>{{ client["client_name"] }}</td>
         {% if client["status"] == "up" %}
         <td>✅ Up</td>
         {% elif client["status"] == "down" %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cos-alerter"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
   { name="Dylan Stephano-Shachter", email="dylan.stephano-shachter@canonical.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "pyyaml~=6.0",
   "timeago~=1.0",
   "waitress~=2.1",
+  "ruamel.yaml~=0.18.0"
 ]
 
 [project.urls]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: cos-alerter
 summary: A liveness checker for self-monitoring.
 description: Receive regular pings from the cos stack and alert when they stop.
-version: "0.5.0"  # NOTE: Make sure this matches `cos-alerter` below
+version: "0.6.0"  # NOTE: Make sure this matches `cos-alerter` below
 base: ubuntu:22.04
 license: Apache-2.0
 platforms:
@@ -11,7 +11,7 @@ parts:
     plugin: python
     source: .
     python-packages:
-      - cos-alerter==0.5.0  # NOTE: Make sure this matches `version` above
+      - cos-alerter==0.6.0  # NOTE: Make sure this matches `version` above
     stage-packages:
       - python3-venv
 services:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cos-alerter
-version: '0.5.0'
+version: '0.6.0'
 summary: A watchdog alerting on alertmanager notification failures.
 license: Apache-2.0
 contact: simon.aronsson@canonical.com

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,7 +10,13 @@ CONFIG = {
     "watch": {
         "down_interval": "5m",
         "wait_for_first_connection": False,
-        "clients": ["client0"],
+        "clients": [
+            {
+                "id": "123e4567-e89b-12d3-a456-426614174001",
+                "key": "jk3h4g5j34h0",
+                "name": "Client 0",
+            }
+        ],
     },
     "notify": {
         "destinations": DESTINATIONS,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,7 +12,7 @@ CONFIG = {
         "wait_for_first_connection": False,
         "clients": {
             "clientid1": {
-                "key": "clientkey1",
+                "key": "822295b207a0b73dd4690b60a03c55599346d44aef3da4cf28c3296eadb98b2647ae18863cc3ae8ae5574191b60360858982fd8a8d176c0edf646ce6eee24ef9",
                 "name": "Instance Name 1",
             },
         },

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,13 +10,12 @@ CONFIG = {
     "watch": {
         "down_interval": "5m",
         "wait_for_first_connection": False,
-        "clients": [
-            {
-                "id": "123e4567-e89b-12d3-a456-426614174001",
-                "key": "jk3h4g5j34h0",
-                "name": "Client 0",
-            }
-        ],
+        "clients": {
+            "clientid1": {
+                "key": "clientkey1",
+                "name": "Instance Name 1",
+            },
+        },
     },
     "notify": {
         "destinations": DESTINATIONS,

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -29,6 +29,31 @@ def test_config_default_empty_file(fake_fs):
     assert config["watch"]["down_interval"] == 300
 
 
+def test_duplicate_key_error(fake_fs):
+    duplicate_config = """
+    watch:
+      down_interval: "5m"
+      wait_for_first_connection: true
+      clients:
+        clientid1:
+          key: "clientkey1"
+          name: "Instance Name 1"
+        clientid1:
+          key: "clientkey1"
+          name: "Instance Name 1"
+    """
+    with open("/etc/cos-alerter.yaml", "w") as f:
+        f.write(duplicate_config)
+
+    try:
+        config.reload()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        # If no exception is raised, fail the test
+        assert False
+
+
 def test_config_default_partial_file(fake_fs):
     conf = yaml.dump({"log_level": "info"})
     with open("/etc/cos-alerter.yaml", "w") as f:

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -50,7 +50,7 @@ def test_config_default_override(fake_fs):
 def test_initialize(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="client0")
+    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
     with state:
         assert state.start_date == 1672531200.0
         assert state.start_time == 1000
@@ -72,7 +72,7 @@ def test_up_time(monotonic_mock, fake_fs):
 def test_is_down_from_initialize(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="client0")
+    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
     with state:
         monotonic_mock.return_value = 1180  # Three minutes have passed
         assert state.is_down() is False
@@ -85,7 +85,7 @@ def test_is_down_from_initialize(monotonic_mock, fake_fs):
 def test_is_down_with_reset_alert_timeout(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="client0")
+    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
     with state:
         monotonic_mock.return_value = 2000
         state.reset_alert_timeout()
@@ -106,7 +106,7 @@ def test_is_down_with_wait_for_first_connection(monotonic_mock, fake_fs):
     config.reload()
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="client0")
+    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
     with state:
         monotonic_mock.return_value = 1500
         assert state.is_down() is False  # 6 minutes have passes but we have not started counting.
@@ -122,7 +122,7 @@ def test_is_down_with_wait_for_first_connection(monotonic_mock, fake_fs):
 def test_is_down(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="client0")
+    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
     with state:
         monotonic_mock.return_value = 2000
         state.reset_alert_timeout()
@@ -137,7 +137,7 @@ def test_is_down(monotonic_mock, fake_fs):
 def test_recently_notified(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="client0")
+    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
     with state:
         state._set_notify_time()
         monotonic_mock.return_value = 2800  # 30 minutes have passed
@@ -153,7 +153,7 @@ def test_recently_notified(monotonic_mock, fake_fs):
 def test_notify(notify_mock, add_mock, monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="client0")
+    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
 
     with state:
         state.notify()
@@ -166,7 +166,7 @@ def test_notify(notify_mock, add_mock, monotonic_mock, fake_fs):
         title="**Alertmanager is Down!**",
         body=textwrap.dedent(
             """
-            Your Alertmanager instance: client0 seems to be down!
+            Your Alertmanager instance: 123e4567-e89b-12d3-a456-426614174001 seems to be down!
             It has not alerted COS-Alerter ever.
             """
         ),

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -50,7 +50,7 @@ def test_config_default_override(fake_fs):
 def test_initialize(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
+    state = AlerterState(clientid="clientid1")
     with state:
         assert state.start_date == 1672531200.0
         assert state.start_time == 1000
@@ -72,7 +72,7 @@ def test_up_time(monotonic_mock, fake_fs):
 def test_is_down_from_initialize(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
+    state = AlerterState(clientid="clientid1")
     with state:
         monotonic_mock.return_value = 1180  # Three minutes have passed
         assert state.is_down() is False
@@ -85,7 +85,7 @@ def test_is_down_from_initialize(monotonic_mock, fake_fs):
 def test_is_down_with_reset_alert_timeout(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
+    state = AlerterState(clientid="clientid1")
     with state:
         monotonic_mock.return_value = 2000
         state.reset_alert_timeout()
@@ -106,7 +106,7 @@ def test_is_down_with_wait_for_first_connection(monotonic_mock, fake_fs):
     config.reload()
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
+    state = AlerterState(clientid="clientid1")
     with state:
         monotonic_mock.return_value = 1500
         assert state.is_down() is False  # 6 minutes have passes but we have not started counting.
@@ -122,7 +122,7 @@ def test_is_down_with_wait_for_first_connection(monotonic_mock, fake_fs):
 def test_is_down(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
+    state = AlerterState(clientid="clientid1")
     with state:
         monotonic_mock.return_value = 2000
         state.reset_alert_timeout()
@@ -137,7 +137,7 @@ def test_is_down(monotonic_mock, fake_fs):
 def test_recently_notified(monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
+    state = AlerterState(clientid="clientid1")
     with state:
         state._set_notify_time()
         monotonic_mock.return_value = 2800  # 30 minutes have passed
@@ -153,7 +153,7 @@ def test_recently_notified(monotonic_mock, fake_fs):
 def test_notify(notify_mock, add_mock, monotonic_mock, fake_fs):
     monotonic_mock.return_value = 1000
     AlerterState.initialize()
-    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
+    state = AlerterState(clientid="clientid1")
 
     with state:
         state.notify()
@@ -166,7 +166,7 @@ def test_notify(notify_mock, add_mock, monotonic_mock, fake_fs):
         title="**Alertmanager is Down!**",
         body=textwrap.dedent(
             """
-            Your Alertmanager instance: 123e4567-e89b-12d3-a456-426614174001 seems to be down!
+            Your Alertmanager instance: clientid1 seems to be down!
             It has not alerted COS-Alerter ever.
             """
         ),

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -54,6 +54,28 @@ def test_duplicate_key_error(fake_fs):
         assert False
 
 
+def test_invalid_hashes(fake_fs):
+    duplicate_config = """
+    watch:
+      down_interval: "5m"
+      wait_for_first_connection: true
+      clients:
+        invalidhashclient:
+          key: "E0E06B8DB6ED8DD4E1FFE98376E606BDF4FE4ABB4AF65BFE8B18FBFA6564D8B3"
+          name: "Instance Name 1"
+    """
+    with open("/etc/cos-alerter.yaml", "w") as f:
+        f.write(duplicate_config)
+
+    try:
+        config.reload()
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:
+        # If no exception is raised, fail the test
+        assert False
+
+
 def test_config_default_partial_file(fake_fs):
     conf = yaml.dump({"log_level": "info"})
     with open("/etc/cos-alerter.yaml", "w") as f:

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -31,7 +31,7 @@ def mock_fs(fake_fs):
                         "wait_for_first_connection": False,
                         "clients": {
                             "clientid1": {
-                                "key": "clientkey1",
+                                "key": "822295b207a0b73dd4690b60a03c55599346d44aef3da4cf28c3296eadb98b2647ae18863cc3ae8ae5574191b60360858982fd8a8d176c0edf646ce6eee24ef9",
                                 "name": "Instance Name 1",
                             },
                         },

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -29,13 +29,12 @@ def mock_fs(fake_fs):
                     "watch": {
                         "down_interval": "4s",
                         "wait_for_first_connection": False,
-                        "clients": [
-                            {
-                                "id": "123e4567-e89b-12d3-a456-426614174001",
-                                "key": "jk3h4g5j34h0",
-                                "name": "Client 0",
-                            }
-                        ],
+                        "clients": {
+                            "clientid1": {
+                                "key": "clientkey1",
+                                "name": "Instance Name 1",
+                            },
+                        },
                     },
                     "notify": {
                         "destinations": DESTINATIONS,
@@ -64,7 +63,7 @@ def test_main(notify_mock, add_mock, mock_fs):
                 "curl",
                 "-X",
                 "POST",
-                "http://localhost:8080/alive?clientid=123e4567-e89b-12d3-a456-426614174001&key=jk3h4g5j34h0",
+                "http://localhost:8080/alive?clientid=clientid1&key=clientkey1",
             ]
         )
         time.sleep(3)  # Would be considered down but we just sent an alive call.

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -29,7 +29,13 @@ def mock_fs(fake_fs):
                     "watch": {
                         "down_interval": "4s",
                         "wait_for_first_connection": False,
-                        "clients": ["client0"],
+                        "clients": [
+                            {
+                                "id": "123e4567-e89b-12d3-a456-426614174001",
+                                "key": "jk3h4g5j34h0",
+                                "name": "Client 0",
+                            }
+                        ],
                     },
                     "notify": {
                         "destinations": DESTINATIONS,
@@ -53,7 +59,14 @@ def test_main(notify_mock, add_mock, mock_fs):
         main_thread.start()
         time.sleep(2)  # Should not be considered down yet.
         notify_mock.assert_not_called()
-        subprocess.call(["curl", "-X", "POST", "http://localhost:8080/alive?clientid=client0"])
+        subprocess.call(
+            [
+                "curl",
+                "-X",
+                "POST",
+                "http://localhost:8080/alive?clientid=123e4567-e89b-12d3-a456-426614174001&key=jk3h4g5j34h0",
+            ]
+        )
         time.sleep(3)  # Would be considered down but we just sent an alive call.
         notify_mock.assert_not_called()
         time.sleep(3)  # It has been > 4 seconds since we last alerted so it should be down.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,9 +9,9 @@ from helpers import CONFIG
 from werkzeug.datastructures import MultiDict
 
 from cos_alerter.alerter import AlerterState, config
-from cos_alerter.server import app
+from cos_alerter.server import app, get_name_for_uuid
 
-PARAMS = {"clientid": "client0"}
+PARAMS = {"clientid": "123e4567-e89b-12d3-a456-426614174001", "key": "jk3h4g5j34h0"}
 
 
 @pytest.fixture
@@ -29,7 +29,9 @@ def test_dashboard_succeeds(flask_client, fake_fs, state_init):
 
 
 def test_alive_succeeds(flask_client, fake_fs, state_init):
-    assert flask_client.post("/alive", query_string=PARAMS).status_code == 200
+    response = flask_client.post("/alive", query_string=PARAMS)
+    assert response.status_code == 200
+    assert response.data.decode("utf-8") == "Success!"
 
 
 def test_alive_other_methods_fail(flask_client, fake_fs, state_init):
@@ -42,7 +44,7 @@ def test_alive_other_methods_fail(flask_client, fake_fs, state_init):
 
 def test_alive_updates_time(flask_client, fake_fs, state_init):
     flask_client.post("/alive", query_string=PARAMS)
-    state = AlerterState(clientid="client0")
+    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
     with state:
         assert state.data["alert_time"] > state.start_time
 
@@ -52,11 +54,20 @@ def test_metrics_succeeds(flask_client, fake_fs, state_init):
 
 
 def test_no_clientid(flask_client, fake_fs, state_init):
-    assert flask_client.post("/alive").status_code == 400
+    response = flask_client.post("/alive")
+    assert response.status_code == 400
+    assert 'Parameters "clientid" and "key" are required.' in response.get_data(as_text=True)
 
 
 def test_wrong_clientid(flask_client, fake_fs, state_init):
-    assert flask_client.post("/alive", query_string={"clientid": "client1"}).status_code == 404
+    response = flask_client.post(
+        "/alive",
+        query_string={"clientid": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "key": "jk3h4g5j34h0"},
+    )
+    assert response.status_code == 404
+    assert "Clientid a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 not found." in response.get_data(
+        as_text=True
+    )
 
 
 def test_duplicate_clientid(flask_client, fake_fs, state_init):
@@ -67,8 +78,74 @@ def test_duplicate_clientid(flask_client, fake_fs, state_init):
     config.reload()
     params = MultiDict(
         [
-            ("clientid", "client0"),
-            ("clientid", "client1"),
+            ("clientid", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
+            ("key", "jk3o4g5j34h0"),
+            ("clientid", "123e4567-e89b-12d3-a456-426614174001"),
+            ("key", "jk3h4g5j34h0"),
         ]
     )
-    assert flask_client.post("/alive", query_string=params).status_code == 400
+    response = flask_client.post("/alive", query_string=params)
+    assert response.status_code == 400
+    assert 'Parameters "clientid" and "key" should be provided exactly once.' in response.get_data(
+        as_text=True
+    )
+
+
+def test_invalid_uuid_format(flask_client, fake_fs, state_init):
+    response = flask_client.post(
+        "/alive", query_string={"clientid": "invalid-uuid", "key": "jk3h4g5j34h0"}
+    )
+    assert response.status_code == 400
+    assert "not a valid UUID" in response.get_data(as_text=True)
+
+
+def test_invalid_key(flask_client, fake_fs, state_init):
+    response = flask_client.post(
+        "/alive",
+        query_string={"clientid": "123e4567-e89b-12d3-a456-426614174001", "key": "incorrect-key"},
+    )
+    assert response.status_code == 401
+    assert "Incorrect key for the specified clientid" in response.get_data(as_text=True)
+
+
+def test_missing_key(flask_client, fake_fs, state_init):
+    response = flask_client.post(
+        "/alive", query_string={"clientid": "123e4567-e89b-12d3-a456-426614174001"}
+    )
+    assert response.status_code == 400
+    assert 'Parameters "clientid" and "key" are required.' in response.get_data(as_text=True)
+
+
+def test_multiple_key_values(flask_client, fake_fs, state_init):
+    response = flask_client.post(
+        "/alive",
+        query_string={"clientid": "123e4567-e89b-12d3-a456-426614174001", "key": ["key1", "key2"]},
+    )
+    assert response.status_code == 400
+    assert 'Parameters "clientid" and "key" should be provided exactly once.' in response.get_data(
+        as_text=True
+    )
+
+
+def test_get_name_for_uuid_found():
+    clients = [
+        {"id": "clientuuid1", "key": "test_key1", "name": "test_name_1"},
+        {"id": "clientuuid2", "key": "test_key2", "name": "test_name_2"},
+    ]
+
+    target_uuid = "clientuuid1"
+    result = get_name_for_uuid(target_uuid, clients)
+
+    assert result == "test_name_1"
+
+
+def test_get_name_for_uuid_not_found():
+    clients = [
+        {"id": "clientuuid1", "key": "test_key1", "name": "test_name_1"},
+        {"id": "clientuuid2", "key": "test_key2", "name": "test_name_2"},
+    ]
+
+    target_uuid = "nonexistent_uuid"
+    result = get_name_for_uuid(target_uuid, clients)
+
+    assert result is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,7 +70,7 @@ def test_wrong_clientid(flask_client, fake_fs, state_init):
 def test_duplicate_clientid(flask_client, fake_fs, state_init):
     conf = copy.deepcopy(CONFIG)
     conf["watch"]["clients"]["clientid2"] = {
-        "key": "clientkey2",
+        "key": "0415b0cad09712bd1ed094bc06ed421231d0603465e9841c959e9f9dcf735c9ce704df7a0c849a4e0db405c916f679a0e6c3f63f9e26191dda8069e1b44a3bc8",
         "name": "Client 2",
     }
     with open("/etc/cos-alerter.yaml", "w") as f:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,9 +9,9 @@ from helpers import CONFIG
 from werkzeug.datastructures import MultiDict
 
 from cos_alerter.alerter import AlerterState, config
-from cos_alerter.server import app, get_name_for_uuid
+from cos_alerter.server import app
 
-PARAMS = {"clientid": "123e4567-e89b-12d3-a456-426614174001", "key": "jk3h4g5j34h0"}
+PARAMS = {"clientid": "clientid1", "key": "clientkey1"}
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def test_dashboard_succeeds(flask_client, fake_fs, state_init):
 def test_alive_succeeds(flask_client, fake_fs, state_init):
     response = flask_client.post("/alive", query_string=PARAMS)
     assert response.status_code == 200
-    assert response.data.decode("utf-8") == "Success!"
+    assert len(response.data) > 0
 
 
 def test_alive_other_methods_fail(flask_client, fake_fs, state_init):
@@ -44,7 +44,7 @@ def test_alive_other_methods_fail(flask_client, fake_fs, state_init):
 
 def test_alive_updates_time(flask_client, fake_fs, state_init):
     flask_client.post("/alive", query_string=PARAMS)
-    state = AlerterState(clientid="123e4567-e89b-12d3-a456-426614174001")
+    state = AlerterState(clientid="clientid1")
     with state:
         assert state.data["alert_time"] > state.start_time
 
@@ -56,93 +56,58 @@ def test_metrics_succeeds(flask_client, fake_fs, state_init):
 def test_no_clientid(flask_client, fake_fs, state_init):
     response = flask_client.post("/alive")
     assert response.status_code == 400
-    assert 'Parameters "clientid" and "key" are required.' in response.get_data(as_text=True)
+    assert len(response.data) > 0
 
 
 def test_wrong_clientid(flask_client, fake_fs, state_init):
     response = flask_client.post(
         "/alive",
-        query_string={"clientid": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "key": "jk3h4g5j34h0"},
+        query_string={"clientid": "clientid2", "key": "clientkey1"},
     )
     assert response.status_code == 404
 
 
 def test_duplicate_clientid(flask_client, fake_fs, state_init):
     conf = copy.deepcopy(CONFIG)
-    conf["watch"]["clients"].append("client1")
+    conf["watch"]["clients"]["clientid2"] = {
+        "key": "clientkey2",
+        "name": "Client 2",
+    }
     with open("/etc/cos-alerter.yaml", "w") as f:
         f.write(yaml.dump(conf))
     config.reload()
     params = MultiDict(
         [
-            ("clientid", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"),
-            ("key", "jk3o4g5j34h0"),
-            ("clientid", "123e4567-e89b-12d3-a456-426614174001"),
-            ("key", "jk3h4g5j34h0"),
+            ("clientid", "clientid1"),
+            ("key", "clientkey1"),
+            ("clientid", "clientid2"),
+            ("key", "clientkey2"),
         ]
     )
     response = flask_client.post("/alive", query_string=params)
     assert response.status_code == 400
-    assert 'Parameters "clientid" and "key" should be provided exactly once.' in response.get_data(
-        as_text=True
-    )
-
-
-def test_invalid_uuid_format(flask_client, fake_fs, state_init):
-    response = flask_client.post(
-        "/alive", query_string={"clientid": "invalid-uuid", "key": "jk3h4g5j34h0"}
-    )
-    assert response.status_code == 400
-    assert "not a valid UUID" in response.get_data(as_text=True)
+    assert len(response.data) > 0
 
 
 def test_invalid_key(flask_client, fake_fs, state_init):
     response = flask_client.post(
         "/alive",
-        query_string={"clientid": "123e4567-e89b-12d3-a456-426614174001", "key": "incorrect-key"},
+        query_string={"clientid": "clientid1", "key": "incorrect-key"},
     )
     assert response.status_code == 401
-    assert "Incorrect key for the specified clientid" in response.get_data(as_text=True)
+    assert len(response.data) > 0
 
 
 def test_missing_key(flask_client, fake_fs, state_init):
-    response = flask_client.post(
-        "/alive", query_string={"clientid": "123e4567-e89b-12d3-a456-426614174001"}
-    )
+    response = flask_client.post("/alive", query_string={"clientid": "clientid1"})
     assert response.status_code == 400
-    assert 'Parameters "clientid" and "key" are required.' in response.get_data(as_text=True)
+    assert len(response.data) > 0
 
 
 def test_multiple_key_values(flask_client, fake_fs, state_init):
     response = flask_client.post(
         "/alive",
-        query_string={"clientid": "123e4567-e89b-12d3-a456-426614174001", "key": ["key1", "key2"]},
+        query_string={"clientid": "clientid1", "key": ["key1", "key2"]},
     )
     assert response.status_code == 400
-    assert 'Parameters "clientid" and "key" should be provided exactly once.' in response.get_data(
-        as_text=True
-    )
-
-
-def test_get_name_for_uuid_found():
-    clients = [
-        {"id": "clientuuid1", "key": "test_key1", "name": "test_name_1"},
-        {"id": "clientuuid2", "key": "test_key2", "name": "test_name_2"},
-    ]
-
-    target_uuid = "clientuuid1"
-    result = get_name_for_uuid(target_uuid, clients)
-
-    assert result == "test_name_1"
-
-
-def test_get_name_for_uuid_not_found():
-    clients = [
-        {"id": "clientuuid1", "key": "test_key1", "name": "test_name_1"},
-        {"id": "clientuuid2", "key": "test_key2", "name": "test_name_2"},
-    ]
-
-    target_uuid = "nonexistent_uuid"
-    result = get_name_for_uuid(target_uuid, clients)
-
-    assert result is None
+    assert len(response.data) > 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -65,9 +65,6 @@ def test_wrong_clientid(flask_client, fake_fs, state_init):
         query_string={"clientid": "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "key": "jk3h4g5j34h0"},
     )
     assert response.status_code == 404
-    assert "Clientid a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11 not found." in response.get_data(
-        as_text=True
-    )
 
 
 def test_duplicate_clientid(flask_client, fake_fs, state_init):

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
     pytest
     pyyaml
     werkzeug
+    ruamel.yaml
 commands =
     coverage run --source {[vars]src_path} -m pytest -m "not slow" -v --log-cli-level=INFO {[vars]tst_path}
 
@@ -59,6 +60,7 @@ deps =
     pyfakefs
     pytest
     pyyaml
+    ruamel.yaml
 commands =
     coverage run -a --source {[vars]src_path} -m pytest -m slow -v --log-cli-level=INFO {[vars]tst_path}
 


### PR DESCRIPTION
## Issue
Rather than listing a simple list of strings in the config file, we should have a more detailed list of clients. https://github.com/canonical/cos-alerter/issues/60


## Solution
Adjust the server logic to receive both client UUID and match it with it's key and then show the client name in the dashboard instead of the id


## Testing Instructions
1. Add a client's details in the cos-alerter config that contain (valid UUID, Key and client's Name)
2. Run COS Alerter.
3. Configure Alertmanager to route the watchdog alert to cos-alerter using the same UUID&Key
4. Validate that heartbeat is received in dashboard


## Release Notes
User is now able to set uuid, key and client's name in cos-alerter config rather than just the client ID
