### PR TITLE
 Container continues to run silently when cos-alerter fails

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -16,9 +16,7 @@ jobs:
         run: |
           pkg_version=$(grep -P -o 'version = "\d+\.\d+\.\d+"' pyproject.toml | grep -P -o '\d+\.\d+\.\d+')
           rock_version=$(grep -P -o 'version: "\d+\.\d+\.\d+"' rockcraft.yaml | grep -P -o '\d+\.\d+\.\d+')
-          rock_pkg_version=$(grep -P -o 'cos-alerter==\d+\.\d+\.\d+' rockcraft.yaml | grep -P -o '\d+\.\d+\.\d+')
           [ "${pkg_version}" == "${rock_version}" ]
-          [ "${rock_version}" == "${rock_pkg_version}" ]
   changelog-check:
     name: Changelog Check
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2024-03-07
+
+- Fixes container silently running by exiting with non-zero status when configuration file is missing. (#70).
+
 ## [0.7.0] - 2024-02-26
 
 - Client state is now retained on a graceful shutdown (#66).

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -46,16 +46,23 @@ class Config:
     def reload(self):
         """Reload config values from the disk."""
         yaml = YAML(typ="rt")
+
+        # Load default configuration
         with open(
             os.path.join(os.path.dirname(os.path.realpath(__file__)), "config-defaults.yaml")
         ) as f:
             self.data = yaml.load(f)
-        with open(self.path, "r") as f:
-            try:
+
+        # Load user configuration
+        try:
+            with open(self.path, "r") as f:
                 user_data = yaml.load(f)
-            except DuplicateKeyError:
-                logger.critical("Duplicate client IDs found in COS Alerter config. Exiting...")
-                sys.exit(1)
+        except FileNotFoundError:
+            logger.critical("Config file not found. Exiting...")
+            sys.exit(1)
+        except DuplicateKeyError:
+            logger.critical("Duplicate client IDs found in COS Alerter config. Exiting...")
+            sys.exit(1)
 
         # Validate that keys are valid SHA-512 hashes
         if user_data and user_data.get("watch", {}).get("clients"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cos-alerter"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
   { name="Dylan Stephano-Shachter", email="dylan.stephano-shachter@canonical.com" }
 ]

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,8 +1,8 @@
 name: cos-alerter
 summary: A liveness checker for self-monitoring.
 description: Receive regular pings from the cos stack and alert when they stop.
-version: "0.7.0"  # NOTE: Make sure this matches `cos-alerter` below
-base: ubuntu:22.04
+version: "0.8.0"  # NOTE: Make sure this matches `cos-alerter` below
+base: ubuntu@22.04
 license: Apache-2.0
 platforms:
   amd64:
@@ -11,7 +11,7 @@ parts:
     plugin: python
     source: .
     python-packages:
-      - cos-alerter==0.7.0  # NOTE: Make sure this matches `version` above
+      - cos-alerter==0.8.0  # NOTE: Make sure this matches `version` above
     stage-packages:
       - python3-venv
 services:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -10,8 +10,6 @@ parts:
   cos-alerter:
     plugin: python
     source: .
-    python-packages:
-      - cos-alerter==0.8.0  # NOTE: Make sure this matches `version` above
     stage-packages:
       - python3-venv
 services:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: cos-alerter
 summary: A liveness checker for self-monitoring.
 description: Receive regular pings from the cos stack and alert when they stop.
-version: "0.8.0"  # NOTE: Make sure this matches `cos-alerter` below
+version: "0.8.0"
 base: ubuntu@22.04
 license: Apache-2.0
 platforms:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: cos-alerter
-version: '0.7.0'
+version: '0.8.0'
 summary: A watchdog alerting on alertmanager notification failures.
 license: Apache-2.0
 contact: simon.aronsson@canonical.com

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -28,10 +28,12 @@ def test_config_default_empty_file(fake_fs):
     config.reload()
     assert config["watch"]["down_interval"] == 300
 
+
 def test_file_not_found_error(fake_fs):
 
-    with unittest.mock.patch("cos_alerter.logger.critical") as mock_critical, \
-         unittest.mock.patch("sys.exit") as mock_exit:
+    with unittest.mock.patch("cos_alerter.logger.critical") as mock_critical, unittest.mock.patch(
+        "sys.exit"
+    ) as mock_exit:
 
         try:
             config.reload()
@@ -41,6 +43,7 @@ def test_file_not_found_error(fake_fs):
             mock_exit.assert_called_once_with(1)
         else:
             assert False
+
 
 def test_duplicate_key_error(fake_fs):
     duplicate_config = """

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import os
 import textwrap
 import threading
 import unittest.mock
@@ -30,17 +31,13 @@ def test_config_default_empty_file(fake_fs):
 
 
 def test_file_not_found_error(fake_fs):
-
-    with unittest.mock.patch("cos_alerter.logger.critical") as mock_critical, unittest.mock.patch(
-        "sys.exit"
-    ) as mock_exit:
-
+    with unittest.mock.patch("cos_alerter.alerter.logger") as mock_logger:
+        os.unlink("/etc/cos-alerter.yaml")
         try:
             config.reload()
         except SystemExit as exc:
             assert exc.code == 1
-            mock_critical.assert_called_once_with("Config file not found. Exiting...")
-            mock_exit.assert_called_once_with(1)
+            mock_logger.critical.assert_called_once_with("Config file not found. Exiting...")
         else:
             assert False
 

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -28,6 +28,19 @@ def test_config_default_empty_file(fake_fs):
     config.reload()
     assert config["watch"]["down_interval"] == 300
 
+def test_file_not_found_error(fake_fs):
+
+    with unittest.mock.patch("cos_alerter.logger.critical") as mock_critical, \
+         unittest.mock.patch("sys.exit") as mock_exit:
+
+        try:
+            config.reload()
+        except SystemExit as exc:
+            assert exc.code == 1
+            mock_critical.assert_called_once_with("Config file not found. Exiting...")
+            mock_exit.assert_called_once_with(1)
+        else:
+            assert False
 
 def test_duplicate_key_error(fake_fs):
     duplicate_config = """


### PR DESCRIPTION
## Issue
Fixes https://github.com/canonical/cos-alerter/issues/38

## Solution
If no configuration file is passed, the code now catches a FileNotFoundError and exits with a non-zero exit status.

## Testing Instructions

1. Run the following command:
`docker run -p 8080:8080 ghcr.io/canonical/cos-alerter:latest`
2. Verify that cos-alerter fails to start and observe the following output:
```
2024-03-07T17:09:29.587Z [pebble] Started daemon.
2024-03-07T17:09:29.601Z [pebble] POST /v1/services 7.02659ms 202
2024-03-07T17:09:29.602Z [pebble] Started default services with change 1.
2024-03-07T17:09:29.611Z [pebble] Service "cos-alerter" starting: /usr/bin/cos-alerter
2024-03-07T17:09:29.915Z [cos-alerter] Config file not found. Exiting...
2024-03-07T17:09:29.960Z [pebble] [change 1 "Start service \"cos-alerter\"" task] failed: cannot start service: exited quickly with code 1
```