### PR TITLE
ci: Fix pull request workflow

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Run Checks
         run: tox -e test,slow-tests
       - name: Upload .coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: .coverage
@@ -74,7 +74,7 @@ jobs:
       - name: Install Dependencies
         run: python3 -m pip install tox
       - name: Download .coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
       - name: Run Checks

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -62,6 +62,7 @@ jobs:
         with:
           name: coverage
           path: .coverage
+          include-hidden-files: true
   coverage:
     name: Coverage
     needs: tests

--- a/.github/workflows/rock-build.yaml
+++ b/.github/workflows/rock-build.yaml
@@ -55,12 +55,12 @@ jobs:
       run: syft $(realpath ./cos-alerter_*.rock) -o spdx-json=cos-alerter.sbom.json
 
     - name: Upload SBOM
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cos-alerter-sbom
         path: "cos-alerter.sbom.json"
     - name: Upload locally built ROCK artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cos-alerter-rock
         path: "cos-alerter_*.rock"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## CI - updates
+
+- Fixed deprecated job versions in the CI
+
 ## [0.9.0] - 2024-05-30
 
 - Added PagerDuty native support (#76).

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -26,7 +26,7 @@ deps =
     codespell
 commands =
     codespell --skip .git --skip .tox --skip build --skip venv
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static]


### PR DESCRIPTION
## Issue
currently the PR workflow does not seem to work, especially the coverage part of the validation seems to fail almost all the time. This is because some deprecated versions of upload and download artifact jobs are used. THis PR fixes this issue.

Also, the ruff commands are updated in the `tox.ini` so the linting and formatting recipes work.

