### PR TITLE
docs: add documentation regarding secure deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added silencing feature
 - Fixed hash comparison to prevent timing analysis based attacks
+- A note on secure deployments
 
 ## CI - updates
 

--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ cos-alerter
 ### Development Builds
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for running development builds.
+
+## Security Considerations
+
+To keep the codebase focused, COS Alerter does not natively encrypt traffic. Additionally, it does not restrict access to the dashboard to avoid providing a false sense of security. It is highly recommended to use a [reverse proxy](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/) with [Basic Auth](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basic-authentication/) and [HTTPS](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/) to secure the deployment.
+
+Alternatively, running the dashboard and the API endpoints on different IP:PORT pairs is also possible. The dashboard can listen on localhost, requiring an SSH tunnel to enforce authenticated access.


### PR DESCRIPTION
## Issue

COS Alerter doesn't encrypt traffic or offer authentication for users. 

Closes #58.

## Solution

To keep the code focused and easier to maintain, no additional feature is added but a recommendation is given for secure deployment.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
