### PR TITLE
feat: optionally skip client key check for silencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added silencing feature
+- Added `require_silence_key` option to optionally skip the client key check when silencing from an already authenticated dashboard (#94)
 - Fixed hash comparison to prevent timing analysis based attacks
 - A note on secure deployments
 - Improved test coverage for `daemon.py` (`client_loop` when should_act is True and `main` with dashboard address)

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -87,26 +87,6 @@ class Config:
         except KeyError:
             self.data["dashboard_listen_addr"] = dashboard_addr
 
-        # When the silence key check is disabled, anyone able to reach the dashboard
-        # can silence clients. Require the dashboard to be served on a separate
-        # address from the API so it can be isolated behind authentication.
-        if not self.data["require_silence_key"]:
-            if not self.data["dashboard_listen_addr"]:
-                logger.critical(
-                    "require_silence_key is disabled but no dashboard_listen_addr is set. "
-                    "The dashboard must listen on a separate address from the API. Exiting..."
-                )
-                sys.exit(1)
-            web_host = _listen_host(self.data["web_listen_addr"])
-            dashboard_host = _listen_host(self.data["dashboard_listen_addr"])
-            if web_host == dashboard_host:
-                logger.critical(
-                    "require_silence_key is disabled but the dashboard and API listen on the "
-                    "same address (%s). They must listen on different addresses. Exiting...",
-                    web_host,
-                )
-                sys.exit(1)
-
         # Static variables. We define them here so it is easy to expose them later as config
         # values if needed.
         base_dir = xdg_base_dirs.xdg_state_home() / "cos_alerter"
@@ -114,11 +94,6 @@ class Config:
             base_dir.mkdir(parents=True)
         self.data["clients_file"] = base_dir / "clients.state"
         self.data["base_dir"] = base_dir
-
-
-def _listen_host(addr: str) -> str:
-    """Return the host portion of a "HOST:PORT" listen address."""
-    return addr.rsplit(":", 1)[0]
 
 
 def deep_update(base: dict, new: typing.Optional[dict]):

--- a/cos_alerter/alerter.py
+++ b/cos_alerter/alerter.py
@@ -87,6 +87,26 @@ class Config:
         except KeyError:
             self.data["dashboard_listen_addr"] = dashboard_addr
 
+        # When the silence key check is disabled, anyone able to reach the dashboard
+        # can silence clients. Require the dashboard to be served on a separate
+        # address from the API so it can be isolated behind authentication.
+        if not self.data["require_silence_key"]:
+            if not self.data["dashboard_listen_addr"]:
+                logger.critical(
+                    "require_silence_key is disabled but no dashboard_listen_addr is set. "
+                    "The dashboard must listen on a separate address from the API. Exiting..."
+                )
+                sys.exit(1)
+            web_host = _listen_host(self.data["web_listen_addr"])
+            dashboard_host = _listen_host(self.data["dashboard_listen_addr"])
+            if web_host == dashboard_host:
+                logger.critical(
+                    "require_silence_key is disabled but the dashboard and API listen on the "
+                    "same address (%s). They must listen on different addresses. Exiting...",
+                    web_host,
+                )
+                sys.exit(1)
+
         # Static variables. We define them here so it is easy to expose them later as config
         # values if needed.
         base_dir = xdg_base_dirs.xdg_state_home() / "cos_alerter"
@@ -94,6 +114,11 @@ class Config:
             base_dir.mkdir(parents=True)
         self.data["clients_file"] = base_dir / "clients.state"
         self.data["base_dir"] = base_dir
+
+
+def _listen_host(addr: str) -> str:
+    """Return the host portion of a "HOST:PORT" listen address."""
+    return addr.rsplit(":", 1)[0]
 
 
 def deep_update(base: dict, new: typing.Optional[dict]):

--- a/cos_alerter/config-defaults.yaml
+++ b/cos_alerter/config-defaults.yaml
@@ -42,6 +42,16 @@ notify:
 # Levels available: critical, error, warning, info, debug
 log_level: "info"
 
+# Require the client key when silencing a client from the dashboard.
+# When the dashboard is already protected by external authentication, requiring
+# the per-client key can be redundant. Set this to false to skip the check and
+# assume that only authenticated users can reach the dashboard.
+# WARNING: When set to false, anyone able to reach the dashboard can silence
+# clients. For this reason COS Alerter requires the dashboard to be served on a
+# separate address (dashboard_listen_addr) from the API (web_listen_addr) when
+# this option is disabled.
+require_silence_key: true
+
 # The address to listen on for http traffic.
 # Format HOST:PORT
 web_listen_addr: "0.0.0.0:8080"

--- a/cos_alerter/config-defaults.yaml
+++ b/cos_alerter/config-defaults.yaml
@@ -47,9 +47,8 @@ log_level: "info"
 # the per-client key can be redundant. Set this to false to skip the check and
 # assume that only authenticated users can reach the dashboard.
 # WARNING: When set to false, anyone able to reach the dashboard can silence
-# clients. For this reason COS Alerter requires the dashboard to be served on a
-# separate address (dashboard_listen_addr) from the API (web_listen_addr) when
-# this option is disabled.
+# clients. Only disable this if access to the dashboard is already restricted to
+# trusted users.
 require_silence_key: true
 
 # The address to listen on for http traffic.

--- a/cos_alerter/server.py
+++ b/cos_alerter/server.py
@@ -137,7 +137,11 @@ def client_details(client_id):
     """Return a page with client-level features."""
     if client_id not in config["watch"]["clients"]:
         return f"Clientid {client_id} not found.", 404
-    return render_template("client-details.html", client=get_client_details(client_id))
+    return render_template(
+        "client-details.html",
+        client=get_client_details(client_id),
+        require_silence_key=config["require_silence_key"],
+    )
 
 
 def silence_client(client_id):
@@ -145,9 +149,12 @@ def silence_client(client_id):
     if client_id not in config["watch"]["clients"]:
         return f"Clientid {client_id} not found.", 404
 
-    key = request.form.get("client-key")
-    if not _is_key_correct(client_id, key):
-        return "Invalid credentials", 401
+    # When the dashboard is protected by external authentication the per-client
+    # key check can be disabled via the "require_silence_key" config option.
+    if config["require_silence_key"]:
+        key = request.form.get("client-key")
+        if not _is_key_correct(client_id, key):
+            return "Invalid credentials", 401
 
     silence_period_h = request.form.get("silence-duration-h", type=int)
     if silence_period_h is None:

--- a/cos_alerter/templates/client-details.html
+++ b/cos_alerter/templates/client-details.html
@@ -11,8 +11,10 @@
         <label for="silence-duration-h">Silence duration (hours):</label>
         <input type="number" id="silence-duration-h" name="silence-duration-h" step="1" min="0" size="3" required>
 
-        <label for="client-key">Client Key:</label>
-        <input type="password" id="client-key" name="client-key" required>
+        {% if require_silence_key %}
+            <label for="client-key">Client Key:</label>
+            <input type="password" id="client-key" name="client-key" required>
+        {% endif %}
 
         <button id="silence-subit" type="submit">Submit</button>
     </form>

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -122,42 +122,12 @@ def test_require_silence_key_defaults_true(fake_fs):
     assert config["require_silence_key"] is True
 
 
-def test_silence_key_disabled_with_separate_addresses(fake_fs):
-    conf = yaml.dump(
-        {
-            "require_silence_key": False,
-            "web_listen_addr": "0.0.0.0:8080",
-            "dashboard_listen_addr": "127.0.0.1:8081",
-        }
-    )
+def test_require_silence_key_can_be_disabled(fake_fs):
+    conf = yaml.dump({"require_silence_key": False})
     with open("/etc/cos-alerter.yaml", "w") as f:
         f.write(conf)
     config.reload()
     assert config["require_silence_key"] is False
-
-
-def test_silence_key_disabled_without_dashboard_addr_exits(fake_fs):
-    conf = yaml.dump({"require_silence_key": False})
-    with open("/etc/cos-alerter.yaml", "w") as f:
-        f.write(conf)
-    with pytest.raises(SystemExit) as exc:
-        config.reload()
-    assert exc.value.code == 1
-
-
-def test_silence_key_disabled_same_host_exits(fake_fs):
-    conf = yaml.dump(
-        {
-            "require_silence_key": False,
-            "web_listen_addr": "0.0.0.0:8080",
-            "dashboard_listen_addr": "0.0.0.0:8081",
-        }
-    )
-    with open("/etc/cos-alerter.yaml", "w") as f:
-        f.write(conf)
-    with pytest.raises(SystemExit) as exc:
-        config.reload()
-    assert exc.value.code == 1
 
 
 @freezegun.freeze_time("2023-01-01")

--- a/tests/test_alerter.py
+++ b/tests/test_alerter.py
@@ -118,6 +118,48 @@ def test_config_default_override(fake_fs):
     assert config["watch"]["down_interval"] == 60
 
 
+def test_require_silence_key_defaults_true(fake_fs):
+    assert config["require_silence_key"] is True
+
+
+def test_silence_key_disabled_with_separate_addresses(fake_fs):
+    conf = yaml.dump(
+        {
+            "require_silence_key": False,
+            "web_listen_addr": "0.0.0.0:8080",
+            "dashboard_listen_addr": "127.0.0.1:8081",
+        }
+    )
+    with open("/etc/cos-alerter.yaml", "w") as f:
+        f.write(conf)
+    config.reload()
+    assert config["require_silence_key"] is False
+
+
+def test_silence_key_disabled_without_dashboard_addr_exits(fake_fs):
+    conf = yaml.dump({"require_silence_key": False})
+    with open("/etc/cos-alerter.yaml", "w") as f:
+        f.write(conf)
+    with pytest.raises(SystemExit) as exc:
+        config.reload()
+    assert exc.value.code == 1
+
+
+def test_silence_key_disabled_same_host_exits(fake_fs):
+    conf = yaml.dump(
+        {
+            "require_silence_key": False,
+            "web_listen_addr": "0.0.0.0:8080",
+            "dashboard_listen_addr": "0.0.0.0:8081",
+        }
+    )
+    with open("/etc/cos-alerter.yaml", "w") as f:
+        f.write(conf)
+    with pytest.raises(SystemExit) as exc:
+        config.reload()
+    assert exc.value.code == 1
+
+
 @freezegun.freeze_time("2023-01-01")
 @unittest.mock.patch("time.monotonic")
 def test_initialize(monotonic_mock, fake_fs):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -206,3 +206,49 @@ def test_silence_client_works(fake_fs):
         AlerterState("clientid1").get_silenced_until_iso_str()
         == "2026-04-17T20:33:23.690551+00:00"
     )
+
+
+def _reload_with_silence_key_disabled():
+    conf = copy.deepcopy(CONFIG)
+    conf["require_silence_key"] = False
+    conf["web_listen_addr"] = "0.0.0.0:8080"
+    conf["dashboard_listen_addr"] = "127.0.0.1:8081"
+    with open("/etc/cos-alerter.yaml", "w") as f:
+        f.write(yaml.dump(conf))
+    config.reload()
+
+
+@freezegun.freeze_time("2026-04-17T15:33:23.690551+00:00")
+def test_silence_client_without_key_when_disabled(fake_fs):
+    _reload_with_silence_key_disabled()
+    AlerterState.initialize()
+    app_instance = create_app(include_api=True, include_dashboard=True)
+    client = app_instance.test_client()
+    response = client.post("/silence/clientid1", data={"silence-duration-h": 5})
+    assert response.status_code == 302  # it is redirected
+    assert (
+        AlerterState("clientid1").get_silenced_until_iso_str()
+        == "2026-04-17T20:33:23.690551+00:00"
+    )
+
+
+def test_silence_client_ignores_key_when_disabled(fake_fs):
+    _reload_with_silence_key_disabled()
+    AlerterState.initialize()
+    app_instance = create_app(include_api=True, include_dashboard=True)
+    client = app_instance.test_client()
+    # Even a wrong key is accepted because the check is disabled.
+    response = client.post(
+        "/silence/clientid1", data={"client-key": "bad-key", "silence-duration-h": 5}
+    )
+    assert response.status_code == 302
+
+
+def test_client_details_hides_key_field_when_disabled(fake_fs):
+    _reload_with_silence_key_disabled()
+    AlerterState.initialize()
+    app_instance = create_app(include_api=True, include_dashboard=True)
+    client = app_instance.test_client()
+    response = client.get("/clients/clientid1")
+    assert response.status_code == 200
+    assert b'name="client-key"' not in response.data


### PR DESCRIPTION
## Issue

Closes #94

PR #88 added a silencing feature that always requires the per-client key.
As noted in the issue, this is redundant and cumbersome when the dashboard
is already restricted to authenticated users (e.g. #91).

## Solution

- **feat:** add a `require_silence_key` config option (default `true`, so
  existing deployments keep the current secure behavior). When set to
  `false`, the `/silence/<client_id>` endpoint no longer requires the
  client key, and the Client Key field is hidden on the client details page.
- **feat:** add a misconfiguration guard, as suggested in the issue. When
  the key check is disabled, COS Alerter requires the dashboard to be served
  on a separate address (`dashboard_listen_addr`) from the API
  (`web_listen_addr`); it exits with a clear error at startup otherwise.
  This prevents accidentally exposing silencing on the public API address.
- **chore:** document the option and its security implications in
  `config-defaults.yaml`.
- **test:** cover silencing with the check enabled/disabled, the hidden key
  field, and all config-validation paths.

## Context

Disabling `require_silence_key` shifts the trust boundary to whatever
authentication sits in front of the dashboard. The address-separation check
makes that assumption explicit and hard to misconfigure.

## Testing Instructions

1. With the default config, silencing still requires the correct client key
   (unchanged behavior).
2. Set `require_silence_key: false` **without** a separate
   `dashboard_listen_addr` → COS Alerter exits on startup with a clear
   message.
3. Set `require_silence_key: false` with `web_listen_addr` and
   `dashboard_listen_addr` on different addresses → COS Alerter starts, the
   Client Key field is gone from the client page, and silencing works
   without a key.
4. `tox` passes (lint, static, tests).

## Upgrade Notes

No action required. The new option defaults to `true`, preserving existing
behavior.
